### PR TITLE
Allow snap to work on Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -81,7 +81,6 @@ function createWindow () {
     show: false,
     titlebarStyle: 'hiddenInset',
     fullscreen: false,
-    transparent: true,
     blur: true,
     blurType: global.blurType,
     modal: true,


### PR DESCRIPTION
Glasstron does not require you to have `transparent` to set to `true`. The blur effect will work as intended. 