### PR TITLE
Publish to Windows Package Managar (WinGet)

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,12 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest # action can only be run on windows
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: SnailDOS.SnailFM
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Before merging this:
1. Please add a GitHub token with `public_repo` scope as a repository secret and rename the secret name in the workflow.
2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under @snaildos.